### PR TITLE
feat!: Switch to streamx

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Artem Medeusheyev & 2020-2021 Blaine Bublitz <blaine.bublitz@gmail.com> and Eric Schoffstall <yo@contra.io>
+Copyright (c) 2014 Artem Medeusheyev & 2020-2022 Blaine Bublitz <blaine.bublitz@gmail.com> and Eric Schoffstall <yo@contra.io>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.js
+++ b/index.js
@@ -33,6 +33,11 @@ function OrderedStreams(streams, options) {
   var readable = new Readable(options);
 
   var streamIdx = 0;
+  var activeStream = streams[streamIdx];
+
+  if (!activeStream) {
+    readable.push(null);
+  }
 
   var destroyedIdx = -1;
   var destroyedByError = false;
@@ -43,26 +48,42 @@ function OrderedStreams(streams, options) {
       throw new Error('All input streams must be readable');
     }
 
-    var readableEnded = false;
-
+    stream.on('data', onData);
     stream.once('error', onError);
     stream.once('end', onEnd);
     stream.once('close', onClose);
 
-    function onError() {
+    stream.pause();
+
+    function cleanup() {
+      stream.off('data', onData);
+      stream.off('error', onError);
+      stream.off('end', onEnd);
+      stream.off('close', onClose);
+    }
+
+    function onError(err) {
       destroyedByError = true;
+      cleanup();
+      readable.destroy(err);
     }
 
     function onEnd() {
-      readableEnded = true;
+      streamIdx++;
+      activeStream = streams[streamIdx];
+      cleanup();
+      if (!activeStream) {
+        readable.push(null);
+      } else {
+        activeStream.resume();
+      }
     }
 
     function onClose() {
       destroyedIdx = idx;
       readableClosed = true;
-      if (!readableEnded) {
-        readable.destroy();
-      }
+      cleanup();
+      readable.destroy();
     }
   });
 
@@ -83,51 +104,18 @@ function OrderedStreams(streams, options) {
     });
   }
 
+  function onData(chunk) {
+    var drained = readable.push(chunk);
+    // If the stream is not drained, we pause the activeStream
+    // The activeStream will be resumed on the next call to `read`
+    if (!drained) {
+      activeStream.pause();
+    }
+  }
+
   function read(cb) {
-    var self = this;
-
-    var activeStream = streams[streamIdx];
-    if (!activeStream) {
-      self.push(null);
-      return cb(null);
-    }
-
-    function cleanup() {
-      activeStream.off('data', onData);
-      activeStream.off('error', onError);
-      activeStream.off('end', onEnd);
-    }
-
-    function onError(err) {
-      cleanup();
-      cb(err);
-    }
-
-    function onEnd() {
-      // When a stream ends, we want to increment index of the stream we are reading from
-      streamIdx++;
-      // Then we want to cleanup handlers on the previously active stream
-      cleanup();
-      // Finally we recursively call this function to read from the next stream
-      read.call(self, cb);
-    }
-
-    function onData(chunk) {
-      var drained = self.push(chunk);
-      // If the stream is not drained, we pause the active stream and cleanup our handlers
-      // The activeStream will be resumed on the next call to `read`
-      if (!drained) {
-        activeStream.pause();
-        cleanup();
-        cb();
-      }
-    }
-
-    activeStream.once('error', onError);
-    activeStream.once('end', onEnd);
-
-    activeStream.on('data', onData);
     activeStream.resume();
+    cb();
   }
 
   return readable;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-var Readable = require('readable-stream/readable');
-var util = require('util');
+var Readable = require('streamx').Readable;
 
 function isReadable(stream) {
   if (typeof stream.pipe !== 'function') {
@@ -10,92 +9,106 @@ function isReadable(stream) {
     return false;
   }
 
-  if (typeof stream._read !== 'function') {
-    return false;
-  }
-
-  if (!stream._readableState) {
+  if (typeof stream.read !== 'function') {
     return false;
   }
 
   return true;
 }
 
-function addStream(streams, stream) {
-  if (!isReadable(stream)) {
-    throw new Error('All input streams must be readable');
-  }
-
-  var self = this;
-
-  stream._buffer = [];
-
-  stream.on('readable', function () {
-    var chunk = stream.read();
-    while (chunk) {
-      if (this === streams[0]) {
-        self.push(chunk);
-      } else {
-        this._buffer.push(chunk);
-      }
-      chunk = stream.read();
-    }
-  });
-
-  stream.on('end', function () {
-    for (
-      var stream = streams[0];
-      stream && stream._readableState.ended;
-      stream = streams[0]
-    ) {
-      while (stream._buffer.length) {
-        self.push(stream._buffer.shift());
-      }
-
-      streams.shift();
-    }
-
-    if (!streams.length) {
-      self.push(null);
-    }
-  });
-
-  stream.on('error', this.emit.bind(this, 'error'));
-
-  streams.push(stream);
-}
-
 function OrderedStreams(streams, options) {
-  if (!(this instanceof OrderedStreams)) {
-    return new OrderedStreams(streams, options);
-  }
-
   streams = streams || [];
-  options = options || {};
-
-  options.objectMode = true;
-
-  Readable.call(this, options);
 
   if (!Array.isArray(streams)) {
     streams = [streams];
   }
-  if (!streams.length) {
-    return this.push(null); // no streams, close
-  }
 
-  var addStreamBinded = addStream.bind(this, []);
+  streams = Array.prototype.concat.apply([], streams);
 
-  streams.forEach(function (item) {
-    if (Array.isArray(item)) {
-      item.forEach(addStreamBinded);
-    } else {
-      addStreamBinded(item);
+  options = Object.assign({}, options, {
+    read: read,
+  });
+
+  streams.forEach(function (stream) {
+    if (!isReadable(stream)) {
+      throw new Error('All input streams must be readable');
     }
   });
-}
-util.inherits(OrderedStreams, Readable);
 
-OrderedStreams.prototype._read = function () {};
+  var streamIdx = 0;
+
+  function read(cb) {
+    var self = this;
+
+    var activeStream = streams[streamIdx];
+    if (!activeStream) {
+      self.push(null);
+      return cb(null);
+    }
+
+    function cleanup() {
+      activeStream.off('readable', onRead);
+      activeStream.off('error', onError);
+      activeStream.off('end', onEnd);
+    }
+
+    function onError(err) {
+      cleanup();
+      cb(err);
+    }
+
+    function onEnd() {
+      // When a stream ends, we want to increment index of the stream we are reading from
+      streamIdx++;
+      // Then we want to cleanup handlers on the previously active stream
+      cleanup();
+      // Finally we recursively call this function to read from the next stream
+      read.call(self, cb);
+    }
+
+    function onRead(chunk) {
+      var drained = true;
+
+      // If the chunk is null, we don't want to cleanup because the
+      // `end` event might be emitted afterwards
+      if (chunk === null) {
+        return;
+      }
+
+      while (chunk !== null && drained) {
+        drained = self.push(chunk);
+        // If our stream is not backpressured, we want to process another chunk
+        if (drained) {
+          chunk = activeStream.read();
+        }
+      }
+
+      cleanup();
+      cb(null);
+    }
+
+    activeStream.once('error', onError);
+    activeStream.once('end', onEnd);
+
+    // Try reading the first chunk
+    var chunk = activeStream.read();
+
+    // If we backpressured the OrderedReadStream, we'll have a chunk
+    // and don't need to wait for a `readable` event
+    if (chunk) {
+      onRead(chunk);
+    } else {
+      // If the first chunk is null we want to wait for `readable` to handle both the first
+      // access and a backpressured stream
+      activeStream.once('readable', function () {
+        // Once `readable`, we need to grab the first chunk before passing it to onRead
+        var chunk = activeStream.read();
+        onRead(chunk);
+      });
+    }
+  }
+
+  return new Readable(options);
+}
 
 module.exports = OrderedStreams;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ordered-read-streams",
   "version": "1.0.1",
-  "description": "Combines array of streams into one read stream in strict order",
+  "description": "Combines array of streams into one Readable stream in strict order.",
   "author": "Gulp Team <team@gulpjs.com> (https://gulpjs.com/)",
   "contributors": [
     "Blaine Bublitz <blaine.bublitz@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,18 @@
   "name": "ordered-read-streams",
   "version": "1.0.1",
   "description": "Combines array of streams into one read stream in strict order",
+  "author": "Gulp Team <team@gulpjs.com> (https://gulpjs.com/)",
+  "contributors": [
+    "Blaine Bublitz <blaine.bublitz@gmail.com>",
+    "Artem Medeu <artem.medeusheyev@gmail.com>"
+  ],
+  "repository": "gulpjs/ordered-read-streams",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10.13.0"
+  },
   "files": [
+    "LICENSE",
     "index.js"
   ],
   "scripts": {
@@ -10,24 +21,17 @@
     "pretest": "npm run lint",
     "test": "nyc mocha --async-only"
   },
-  "repository": "gulpjs/ordered-read-streams",
-  "author": "Gulp Team <team@gulpjs.com> (https://gulpjs.com/)",
-  "license": "MIT",
-  "engines": {
-    "node": ">= 10.13.0"
-  },
   "dependencies": {
-    "readable-stream": "^3.6.0"
+    "streamx": "^2.12.5"
   },
   "devDependencies": {
     "eslint": "^7.32.0",
     "eslint-config-gulp": "^5.0.1",
     "eslint-plugin-node": "^11.1.0",
     "expect": "^27.4.2",
-    "mississippi": "^4.0.0",
     "mocha": "^8.4.0",
     "nyc": "^15.1.0",
-    "through2": "^4.0.2"
+    "readable-stream": "^3.6.0"
   },
   "nyc": {
     "reporter": [
@@ -37,5 +41,13 @@
   },
   "prettier": {
     "singleQuote": true
-  }
+  },
+  "keywords": [
+    "streams",
+    "ordered",
+    "group",
+    "combine",
+    "streamx",
+    "readable"
+  ]
 }

--- a/test/main.js
+++ b/test/main.js
@@ -227,7 +227,11 @@ function suite(moduleName) {
         { value: 'data9' },
       ]);
 
-      var streams = new OrderedStreams([s1, s2, s3], { highWaterMark: 1 });
+      var highWaterMark = moduleName === 'streamx' ? 1024 : 1;
+
+      var streams = new OrderedStreams([s1, s2, s3], {
+        highWaterMark: highWaterMark,
+      });
 
       function assert(results) {
         expect(results.length).toEqual(9);
@@ -370,17 +374,15 @@ function suite(moduleName) {
       });
       streams.on('close', function () {
         closed.push('wrapper');
+        assert();
       });
 
       function assert() {
         if (closed.length === 4) {
-          // `destroy` called upon
-          expect(closed[0]).toEqual('s2');
-          // Wrapper destroyed first
-          expect(closed[1]).toEqual('wrapper');
-          // Then the other 2 streams get destroyed
-          expect(closed[2]).toEqual('s1');
-          expect(closed[3]).toEqual('s3');
+          expect(closed).toContain('s2');
+          expect(closed).toContain('wrapper');
+          expect(closed).toContain('s1');
+          expect(closed).toContain('s3');
 
           done();
         }

--- a/test/main.js
+++ b/test/main.js
@@ -1,145 +1,320 @@
 var expect = require('expect');
 
-var miss = require('mississippi');
-
 var OrderedStreams = require('..');
 
-var to = miss.to;
-var from = miss.from;
-var pipe = miss.pipe;
-var concat = miss.concat;
+function suite(moduleName) {
+  var stream = require(moduleName);
 
-function fromOnce(fn) {
-  var called = false;
-  return from.obj(function (size, next) {
-    if (called) {
-      return next(null, null);
-    }
-    called = true;
-    fn.apply(this, arguments);
+  function fromOnce(fn) {
+    var called = false;
+    return new stream.Readable({
+      objectMode: true,
+      read: function (cb) {
+        var self = this;
+        if (called) {
+          this.push(null);
+          if (typeof cb === 'function') {
+            cb(null);
+          }
+          return;
+        }
+        fn(function (err, chunk) {
+          called = true;
+          if (!err) {
+            self.push(chunk);
+          }
+
+          if (typeof cb === 'function') {
+            cb(err);
+          } else {
+            if (err) {
+              return self.destroy(err);
+            }
+          }
+        });
+      },
+    });
+  }
+
+  function concat(fn, timeout) {
+    var items = [];
+    return new stream.Writable({
+      objectMode: true,
+      write: function (chunk, enc, cb) {
+        if (typeof enc === 'function') {
+          cb = enc;
+        }
+        setTimeout(function () {
+          items.push(chunk);
+          cb();
+        }, timeout || 1);
+      },
+      final: function (cb) {
+        if (typeof fn === 'function') {
+          fn(items);
+        }
+
+        cb();
+      },
+    });
+  }
+
+  describe('ordered-read-streams (' + moduleName + ')', function () {
+    it('ends if no streams are given', function (done) {
+      var streams = new OrderedStreams();
+
+      stream.pipeline([streams, concat()], done);
+    });
+
+    it('throws an error if stream is not readable', function (done) {
+      var writable = new stream.Writable({ write: function () {} });
+
+      function withWritable() {
+        new OrderedStreams(writable);
+      }
+
+      expect(withWritable).toThrow('All input streams must be readable');
+
+      done();
+    });
+
+    it('throws an error if stream does not have a _read function', function (done) {
+      function FakeReadable() {
+        this.readable = true;
+        this.pipe = function () {};
+      }
+
+      function withoutRead() {
+        new OrderedStreams(new FakeReadable());
+      }
+
+      expect(withoutRead).toThrow('All input streams must be readable');
+
+      done();
+    });
+
+    it('emits data from all streams', function (done) {
+      var s1 = stream.Readable.from([{ value: 'stream 1' }]);
+      var s2 = stream.Readable.from([{ value: 'stream 2' }]);
+      var s3 = stream.Readable.from([{ value: 'stream 3' }]);
+
+      var streams = new OrderedStreams([s1, s2, s3]);
+
+      function assert(results) {
+        expect(results.length).toEqual(3);
+        expect(results[0]).toEqual({ value: 'stream 1' });
+        expect(results[1]).toEqual({ value: 'stream 2' });
+        expect(results[2]).toEqual({ value: 'stream 3' });
+      }
+
+      stream.pipeline([streams, concat(assert)], done);
+    });
+
+    it('works without new keyword', function (done) {
+      var s1 = stream.Readable.from([{ value: 'stream 1' }]);
+      var s2 = stream.Readable.from([{ value: 'stream 2' }]);
+      var s3 = stream.Readable.from([{ value: 'stream 3' }]);
+
+      var ordered = OrderedStreams;
+
+      var streams = ordered([s1, s2, s3]);
+
+      function assert(results) {
+        expect(results.length).toEqual(3);
+        expect(results[0]).toEqual({ value: 'stream 1' });
+        expect(results[1]).toEqual({ value: 'stream 2' });
+        expect(results[2]).toEqual({ value: 'stream 3' });
+      }
+
+      stream.pipeline([streams, concat(assert)], done);
+    });
+
+    it('flattens arrays of streams 1 levels deep', function (done) {
+      var s1 = stream.Readable.from([{ value: 'stream 1' }]);
+      var s2 = stream.Readable.from([{ value: 'stream 2' }]);
+      var s3 = stream.Readable.from([{ value: 'stream 3' }]);
+
+      var streams = new OrderedStreams([s1, [s2, s3]]);
+
+      function assert(results) {
+        expect(results.length).toEqual(3);
+        expect(results[0]).toEqual({ value: 'stream 1' });
+        expect(results[1]).toEqual({ value: 'stream 2' });
+        expect(results[2]).toEqual({ value: 'stream 3' });
+      }
+
+      stream.pipeline([streams, concat(assert)], done);
+    });
+
+    it('does not allow changing our read function', function (done) {
+      var s1 = stream.Readable.from([{ value: 'stream 1' }]);
+      var s2 = stream.Readable.from([{ value: 'stream 2' }]);
+      var s3 = stream.Readable.from([{ value: 'stream 3' }]);
+
+      var streams = new OrderedStreams([s1, s2, s3], {
+        read: function () {
+          throw new Error('boom');
+        },
+      });
+
+      function assert(results) {
+        expect(results.length).toEqual(3);
+        expect(results[0]).toEqual({ value: 'stream 1' });
+        expect(results[1]).toEqual({ value: 'stream 2' });
+        expect(results[2]).toEqual({ value: 'stream 3' });
+      }
+
+      stream.pipeline([streams, concat(assert)], done);
+    });
+
+    it('emits all data event from each stream', function (done) {
+      var s = stream.Readable.from([
+        { value: 'data1' },
+        { value: 'data2' },
+        { value: 'data3' },
+      ]);
+
+      var streams = new OrderedStreams(s);
+
+      function assert(results) {
+        expect(results.length).toEqual(3);
+      }
+
+      stream.pipeline([streams, concat(assert)], done);
+    });
+
+    it('respects highWaterMark', function (done) {
+      this.timeout(5000);
+
+      var s1 = stream.Readable.from(
+        [{ value: 'data1' }, { value: 'data2' }, { value: 'data3' }],
+        { highWaterMark: 1 }
+      );
+      var s2 = stream.Readable.from(
+        [{ value: 'data4' }, { value: 'data5' }, { value: 'data6' }],
+        { highWaterMark: 1 }
+      );
+      var s3 = stream.Readable.from(
+        [{ value: 'data7' }, { value: 'data8' }, { value: 'data9' }],
+        { highWaterMark: 1 }
+      );
+
+      var streams = new OrderedStreams([s1, s2, s3]);
+
+      function assert(results) {
+        expect(results.length).toEqual(9);
+      }
+
+      stream.pipeline([streams, concat(assert, 250)], done);
+    });
+
+    it('can set highWaterMark on self', function (done) {
+      this.timeout(5000);
+
+      var s1 = stream.Readable.from([
+        { value: 'data1' },
+        { value: 'data2' },
+        { value: 'data3' },
+      ]);
+      var s2 = stream.Readable.from([
+        { value: 'data4' },
+        { value: 'data5' },
+        { value: 'data6' },
+      ]);
+      var s3 = stream.Readable.from([
+        { value: 'data7' },
+        { value: 'data8' },
+        { value: 'data9' },
+      ]);
+
+      var streams = new OrderedStreams([s1, s2, s3], { highWaterMark: 1 });
+
+      function assert(results) {
+        expect(results.length).toEqual(9);
+      }
+
+      stream.pipeline([streams, concat(assert, 250)], done);
+    });
+
+    it('preserves streams order', function (done) {
+      var s1 = fromOnce(function (next) {
+        setTimeout(function () {
+          next(null, { value: 'stream 1' });
+        }, 200);
+      });
+      var s2 = fromOnce(function (next) {
+        setTimeout(function () {
+          next(null, { value: 'stream 2' });
+        }, 30);
+      });
+      var s3 = fromOnce(function (next) {
+        setTimeout(function () {
+          next(null, { value: 'stream 3' });
+        }, 100);
+      });
+
+      var streams = new OrderedStreams([s1, s2, s3]);
+
+      function assert(results) {
+        expect(results.length).toEqual(3);
+        expect(results[0]).toEqual({ value: 'stream 1' });
+        expect(results[1]).toEqual({ value: 'stream 2' });
+        expect(results[2]).toEqual({ value: 'stream 3' });
+      }
+
+      stream.pipeline([streams, concat(assert)], done);
+    });
+
+    it('emits stream errors downstream', function (done) {
+      var s = fromOnce(function (next) {
+        setTimeout(function () {
+          next(new Error('stahp!'));
+        }, 500);
+      });
+      var s2 = stream.Readable.from([{ value: 'Im ok!' }]);
+
+      var streams = new OrderedStreams([s, s2]);
+
+      function assert(err) {
+        expect(err.message).toEqual('stahp!');
+        done();
+      }
+
+      stream.pipeline([streams, concat()], assert);
+    });
+
+    it('emits received data before a stream errors downstream', function (done) {
+      var s = fromOnce(function (next) {
+        setTimeout(function () {
+          next(new Error('stahp!'));
+        }, 500);
+      });
+      var s2 = stream.Readable.from([{ value: 'Im ok!' }]);
+
+      // Invert the order to emit data first
+      var streams = new OrderedStreams([s2, s]);
+
+      function assertData(chunk, enc, next) {
+        if (typeof enc === 'function') {
+          next = enc;
+        }
+        expect(chunk).toEqual({ value: 'Im ok!' });
+        next();
+      }
+
+      function assertErr(err) {
+        expect(err.message).toEqual('stahp!');
+        done();
+      }
+
+      stream.pipeline(
+        [streams, new stream.Writable({ objectMode: true, write: assertData })],
+        assertErr
+      );
+    });
   });
 }
 
-describe('ordered-read-streams', function () {
-  it('ends if no streams are given', function (done) {
-    var streams = new OrderedStreams();
-
-    pipe([streams, concat()], done);
-  });
-
-  it('throws an error if stream is not readable', function (done) {
-    var writable = to();
-
-    function withWritable() {
-      new OrderedStreams(writable);
-    }
-
-    expect(withWritable).toThrow('All input streams must be readable');
-
-    done();
-  });
-
-  it('emits data from all streams', function (done) {
-    var s1 = from.obj([{ value: 'stream 1' }]);
-    var s2 = from.obj([{ value: 'stream 2' }]);
-    var s3 = from.obj([{ value: 'stream 3' }]);
-
-    var streams = new OrderedStreams([s1, s2, s3]);
-
-    function assert(results) {
-      expect(results.length).toEqual(3);
-      expect(results[0]).toEqual({ value: 'stream 1' });
-      expect(results[1]).toEqual({ value: 'stream 2' });
-      expect(results[2]).toEqual({ value: 'stream 3' });
-    }
-
-    pipe([streams, concat(assert)], done);
-  });
-
-  it('emits all data event from each stream', function (done) {
-    var s = from.obj([
-      { value: 'data1' },
-      { value: 'data2' },
-      { value: 'data3' },
-    ]);
-
-    var streams = new OrderedStreams(s);
-
-    function assert(results) {
-      expect(results.length).toEqual(3);
-    }
-
-    pipe([streams, concat(assert)], done);
-  });
-
-  it('preserves streams order', function (done) {
-    var s1 = fromOnce(function (size, next) {
-      setTimeout(function () {
-        next(null, { value: 'stream 1' });
-      }, 200);
-    });
-    var s2 = fromOnce(function (size, next) {
-      setTimeout(function () {
-        next(null, { value: 'stream 2' });
-      }, 30);
-    });
-    var s3 = fromOnce(function (size, next) {
-      setTimeout(function () {
-        next(null, { value: 'stream 3' });
-      }, 100);
-    });
-
-    var streams = new OrderedStreams([s1, s2, s3]);
-
-    function assert(results) {
-      expect(results.length).toEqual(3);
-      expect(results[0]).toEqual({ value: 'stream 1' });
-      expect(results[1]).toEqual({ value: 'stream 2' });
-      expect(results[2]).toEqual({ value: 'stream 3' });
-    }
-
-    pipe([streams, concat(assert)], done);
-  });
-
-  it('emits stream errors downstream', function (done) {
-    var s = fromOnce(function (size, next) {
-      setTimeout(function () {
-        next(new Error('stahp!'));
-      }, 500);
-    });
-    var s2 = from.obj([{ value: 'Im ok!' }]);
-
-    var streams = new OrderedStreams([s, s2]);
-
-    function assert(err) {
-      expect(err.message).toEqual('stahp!');
-      done();
-    }
-
-    pipe([streams, concat()], assert);
-  });
-
-  it('emits received data before a stream errors downstream', function (done) {
-    var s = fromOnce(function (size, next) {
-      setTimeout(function () {
-        next(new Error('stahp!'));
-      }, 500);
-    });
-    var s2 = from.obj([{ value: 'Im ok!' }]);
-
-    // Invert the order to emit data first
-    var streams = new OrderedStreams([s2, s]);
-
-    function assertData(chunk, enc, next) {
-      expect(chunk).toEqual({ value: 'Im ok!' });
-      next();
-    }
-
-    function assertErr(err) {
-      expect(err.message).toEqual('stahp!');
-      done();
-    }
-
-    pipe([streams, to.obj(assertData)], assertErr);
-  });
-});
+suite('stream');
+suite('streamx');
+suite('readable-stream');


### PR DESCRIPTION
This PR almost completely rewrites this entire module. It started as a streamx rewrite but then I noticed that it was consuming streams as fast as it possibly could, which totally defeats the purpose of streams and backpressure. So I changed the implementation to only consume data it needs and respect backpressure in either stream (the parent or children).

I also updated the tests so they are running the different stream implementations.
And I changed the README since it didn't accurately reflect the implementation anymore.

Coverage should be at 100% now too.

Closes #24 

Closes #18 (since it no longer consumes eagerly)
Closes #16 (since it no longer consumes eagerly)